### PR TITLE
REST gyak, tweaking put

### DIFF
--- a/Gyak6-REST/README.md
+++ b/Gyak6-REST/README.md
@@ -287,17 +287,20 @@ namespace restgyak.Controllers
         // PUT api/termek/id
         [HttpPut]
         [Route("{id}")]
-        public ActionResult Modify([FromBody] Models.Termek valtozas)
+        public ActionResult Modify([FromRoute] int id, [FromBody] Models.Termek modositott)
         {
-            var dbTermek = dbContext.Termek.SingleOrDefault(t => t.Id == valtozas.Id);
+            if (id != modositott.Id)
+                return BadRequest();
+
+            var dbTermek = dbContext.Termek.SingleOrDefault(t => t.Id == id);
 
             if (dbTermek == null)
                 return NotFound();
 
             // modositasok elvegzese
-            dbTermek.Nev = valtozas.Nev;
-            dbTermek.NettoAr = valtozas.NettoAr;
-            dbTermek.Raktarkeszlet = valtozas.Raktarkeszlet;
+            dbTermek.Nev = modositott.Nev;
+            dbTermek.NettoAr = modositott.NettoAr;
+            dbTermek.Raktarkeszlet = modositott.Raktarkeszlet;
 
             // mentes az adatbazisban
             dbContext.SaveChanges();


### PR DESCRIPTION
A rest gyakorlatnál a put (Modify) vonatkozásában teszek módosítási javaslatot:
* Az url-re a Route attribútummal rá van mappelve az id (ez így is van jól, PUT esetén benne kell legyen az URL végén az erőforrás azonosító), viszont a kód ezt nem használja.  A módosított verzióban ezt használja, és  meg is nézi, hogy a paraméterben kapott objektum azonosítójával egyezik-e. Ha nem, BadRequest-et ad vissza. 
* A paramétert átneveztem valtozas-ról modositott-ra. Put logikailag "replace"-t jelent, mindent lecserélünk, ehhez jobban passzol a modositott név. Illetve a Create-ben "uj" a név", ehhez is kicsit jobban talál a "modositott".